### PR TITLE
ci: add workflow for compliance tests

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -11,16 +11,53 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ncs/nrfxlib
-          # ref: ${{ github.event.pull_request.head.sha }}
-          # fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: cache-pip
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-doc-pip
+
       - name: Run Compliance Tests
         env:
           BASE_REF: ${{ github.base_ref }}
         working-directory: ncs
         run: |
+          pip3 install -U pip
+          pip3 install -U setuptools
+          export PATH="$HOME/.local/bin:$PATH"
+          pip3 install -U west
           west init -m https://github.com/nrfconnect/sdk-nrf
           west update zephyr
           export ZEPHYR_BASE=$(pwd)/zephyr
+          pip install -U gitlint
+          pip install -r zephyr/scripts/requirements-compliance.txt
           cd nrfxlib
-          echo ok
           $ZEPHYR_BASE/scripts/ci/check_compliance.py -m Codeowners -m Devicetree -m Gitlint -m Identity -m Nits -m pylint -m checkpatch -m Kconfig -c origin/${BASE_REF}.. || true
+
+      - name: Upload Results
+        uses: actions/upload-artifact@master
+        continue-on-error: True
+        with:
+          name: compliance.xml
+          path: ncs/nrfxlib/compliance.xml
+
+      - name: Check Warnings
+        run: |
+          for file in Codeowners.txt Devicetree.txt Gitlint.txt Identity.txt Nits.txt pylint.txt checkpatch.txt Kconfig.txt; do
+            path="ncs/nrfxlib/${file}"
+            if [[ -s $path ]]; then
+              errors=$(cat $path)
+              errors="${errors//'%'/'%25'}"
+              errors="${errors//$'\n'/'%0A'}"
+              errors="${errors//$'\r'/'%0D'}"
+              echo "::error file=${file}::$errors"
+              exit=1
+            fi
+          done
+
+          if [[ $exit == 1 ]]; then
+            exit 1
+          fi


### PR DESCRIPTION
Add compliance test on GH directly from the Zephyr tree.